### PR TITLE
Fix three code bugs

### DIFF
--- a/backend/handlers/SocketHandlers.js
+++ b/backend/handlers/SocketHandlers.js
@@ -333,7 +333,21 @@ class SocketHandlers {
     socket.on('createFolder', (data) => {
       console.log('Create folder requested:', data);
       
-      const result = this.fileBrowserService.createFolder(data.path);
+      // Support both new and legacy parameter shapes
+      const parentPath = typeof data.parentPath === 'string' ? data.parentPath
+        : (typeof data.path === 'string' ? data.path : null);
+      const folderName = typeof data.folderName === 'string' ? data.folderName
+        : (typeof data.name === 'string' ? data.name : null);
+
+      if (!parentPath || !folderName) {
+        socket.emit('folderCreated', {
+          success: false,
+          error: 'Both parentPath and folderName are required'
+        });
+        return;
+      }
+
+      const result = this.fileBrowserService.createFolder(parentPath, folderName);
       socket.emit('folderCreated', result);
     });
   }


### PR DESCRIPTION
Refactor `createFolder` socket handler to accept `parentPath` and `folderName`.

This aligns the handler's expected parameters with the `FileBrowserService.createFolder` method signature, improving clarity and robustness, while maintaining backward compatibility for legacy clients.

---
<a href="https://cursor.com/background-agent?bcId=bc-f2ac91a7-28d1-4f23-a0fd-eb9f771e7122"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-f2ac91a7-28d1-4f23-a0fd-eb9f771e7122"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Socket createFolder now accepts parentPath/folderName with validation; file routes use spawn-based platform-specific opener and support file query alias.
> 
> - **Socket handlers (`backend/handlers/SocketHandlers.js`)**:
>   - **Create folder**: Accepts both `parentPath`/`folderName` and legacy `path`/`name`; validates inputs and emits error on missing; calls `createFolder(parentPath, folderName)`; response via `folderCreated`.
> - **API routes (`backend/routes/apiRoutes.js`)**:
>   - **File preview `GET /file`**: Accepts `path` or `file` query; decodes safely; unchanged validations/streaming.
>   - **Open file `POST /open-file`**: Replace shell `exec` with `spawn` using platform-specific commands (Windows Powershell `Start-Process`, macOS `open`, Linux `xdg-open`); handle spawn errors; respond success on dispatch.
>   - Replace `exec` import with `spawn`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 718d811eb74c8f31683d2d4e063d4feb4a776408. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->